### PR TITLE
Use the latest available version of opensearch-net-abstraction packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,6 +25,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Controls the version of packages from opensearch-net-abstractions -->
+    <!-- *-* means most recent package, including pre-release, will be used. -->
+    <OSNetAbstractionsNuGetVersion>*-*</OSNetAbstractionsNuGetVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <!-- Default Version numbers -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <!-- Type Providers are restored using net461, fine for netcoreapp2.2 so we kill the warning -->
     <NoWarn>$(NoWarn);NU1701</NoWarn>
+    <RestoreLockedMode>false</RestoreLockedMode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Commandline.fs" />
@@ -34,7 +35,7 @@
     <PackageReference Include="FSharp.Core" Version="5.0.0" />
 
     <PackageReference Include="Bullseye" Version="3.3.0" />
-    <PackageReference Include="OpenSearch.OpenSearch.Managed" Version="0.1.0-canary.0.17" />
+    <PackageReference Include="OpenSearch.OpenSearch.Managed" Version="$(OSNetAbstractionsNuGetVersion)" />
     
     <PackageReference Include="Fake.Core.Environment" Version="5.15.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- CAC001: We dont want to set ConfigureAwait() in tests, assume who evers calling our lib doesn't do this either.-->
     <NoWarn>CAC001</NoWarn>
+    <RestoreLockedMode>false</RestoreLockedMode>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TestPackageVersion)'!=''">
     <RestoreSources>$(SolutionRoot)/build/output;https://api.nuget.org/v3/index.json</RestoreSources>

--- a/tests/Tests.Configuration/Tests.Configuration.csproj
+++ b/tests/Tests.Configuration/Tests.Configuration.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenSearch.OpenSearch.Managed" Version="0.1.0-canary.0.17" />
+    <PackageReference Include="OpenSearch.OpenSearch.Managed" Version="$(OSNetAbstractionsNuGetVersion)" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -16,7 +16,7 @@
     
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="OpenSearch.OpenSearch.Xunit" Version="0.1.0-canary.0.17" />
+    <PackageReference Include="OpenSearch.OpenSearch.Xunit" Version="$(OSNetAbstractionsNuGetVersion)" />
     <PackageReference Include="JunitXml.TestLogger" Version="2.1.78" />
     
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />

--- a/tests/Tests.Domain/Tests.Domain.csproj
+++ b/tests/Tests.Domain/Tests.Domain.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="OpenSearch.OpenSearch.Managed" Version="0.1.0-canary.0.17" />
+    <PackageReference Include="OpenSearch.OpenSearch.Managed" Version="$(OSNetAbstractionsNuGetVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Summary
These changes simplify integrating with a new version of opensearch-net-abstractions:
1. Package version is specified in only one place,
2. After a new npkg is available, it can be tested  without updating opensearch-net in several places.

### Details
- Add an MSBuild property -- OSNetAbstractionsNuGetVersion -- that control the version of packages from opensearch-net-abstractions. It is defined in .\Directory.Build.props
- Update scripts.fsproj, Tests.Configuration.csproj, TestsCore.csprojc, Tests.Domain.csproj to use OSNetAbstractionsNuGetVersion.
- Disable nuget restore lock mode for test-related projects that depend on -net-abstractions. This simplifies with updating -net-abstractions until it is released.

### Additional Reviewers
@raymond-lum
@kylepbit
@Yury-Fridlyand
@guiangumpac
@alexmeizer 
