### PR TITLE
Fix typos in scripts

### DIFF
--- a/build/scripts/ReleaseNotes.fs
+++ b/build/scripts/ReleaseNotes.fs
@@ -76,7 +76,7 @@ module ReleaseNotes =
             ("Uncategorized", "Uncategorized")
         ]
         uncategorized = "Uncategorized"
-    };
+    }
         
     let groupByLabel (config: Config) (items: List<GitHubItem>) =
         let dict = Dictionary<string, GitHubItem list>()     

--- a/build/scripts/XmlDocPatcher.fs
+++ b/build/scripts/XmlDocPatcher.fs
@@ -55,7 +55,7 @@ module InheritDoc =
         relatedInterfaceDescriptorRequest;
         relatedInterfaceDescriptorGeneric;
         manualMapping
-    ];
+    ]
     
     let private documentedApis (file:string) =
         use reader = XmlReader.Create file


### PR DESCRIPTION
### Description
Semicolons are not required in F#, but VS compilers threat them as errors. Fortunately, these errors were suppressed, so we were able to compile and run tests.
This PR is going to remove them.
 
### Issues Resolved
![image](https://user-images.githubusercontent.com/88679692/160220029-895f9f59-7ea6-4127-b32e-fcc020dba534.png)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
