### PR TITLE
Change default to use SSL in tests

### DIFF
--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
@@ -66,7 +66,7 @@ namespace Tests.Core.ManagedOpenSearch.Clusters
 	{
 		public ClientTestClusterConfiguration(params OpenSearchPlugin[] plugins) : this(numberOfNodes: 1, plugins: plugins) { }
 
-		public ClientTestClusterConfiguration(ClusterFeatures features = ClusterFeatures.None, int numberOfNodes = 1,
+		public ClientTestClusterConfiguration(ClusterFeatures features = ClusterFeatures.SSL, int numberOfNodes = 1,
 			params OpenSearchPlugin[] plugins
 		)
 			: base(TestClient.Configuration.OpenSearchVersion, Configuration.TestConfiguration.Instance.ServerType, features, new OpenSearchPlugins(plugins), numberOfNodes)


### PR DESCRIPTION
Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

Change default parameter for the base for all `Cluster` classes to use `SSL` in tests. Derived classes may specify another settings, but none of them does this.
To have tests working properly, fix from #14 is also required.