### PR TITLE
Enabled SSL in tests by default. Fixed test client to always use SSL

### DIFF
--- a/tests/Tests.Core/Extensions/EphemeralClusterExtensions.cs
+++ b/tests/Tests.Core/Extensions/EphemeralClusterExtensions.cs
@@ -26,10 +26,9 @@
 */
 
 using System;
-using System.Security.Cryptography.X509Certificates;
- using OpenSearch.OpenSearch.Ephemeral;
- using OpenSearch.OpenSearch.Xunit;
- using OpenSearch.Net;
+using OpenSearch.OpenSearch.Ephemeral;
+using OpenSearch.OpenSearch.Xunit;
+using OpenSearch.Net;
 using Osc;
 using Tests.Core.Client.Settings;
 
@@ -61,13 +60,15 @@ namespace Tests.Core.Extensions
 					&& current.ApiKeyAuthenticationCredentials == null
 					&& current.ClientCertificates == null;
 
+				if (notAlreadyAuthenticated)
+					settings = settings.BasicAuthentication(ClusterAuthentication.Admin.Username,
+															ClusterAuthentication.Admin.Password);
+
 				var noCertValidation = current.ServerCertificateValidationCallback == null;
 
 				if (cluster.ClusterConfiguration.EnableSsl && noCertValidation)
 				{
 					//todo use CA callback instead of allowall
-					// ReSharper disable once UnusedVariable
-					var ca = new X509Certificate2(cluster.ClusterConfiguration.FileSystem.CaCertificate);
 					settings = settings.ServerCertificateValidationCallback(CertificateValidations.AllowAll);
 				}
 				var client = new OpenSearchClient(settings);

--- a/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
+++ b/tests/Tests.Core/ManagedOpenSearch/Clusters/ClientTestClusterBase.cs
@@ -66,7 +66,7 @@ namespace Tests.Core.ManagedOpenSearch.Clusters
 	{
 		public ClientTestClusterConfiguration(params OpenSearchPlugin[] plugins) : this(numberOfNodes: 1, plugins: plugins) { }
 
-		public ClientTestClusterConfiguration(ClusterFeatures features = ClusterFeatures.None, int numberOfNodes = 1,
+		public ClientTestClusterConfiguration(ClusterFeatures features = ClusterFeatures.SSL, int numberOfNodes = 1,
 			params OpenSearchPlugin[] plugins
 		)
 			: base(TestClient.Configuration.OpenSearchVersion, Configuration.TestConfiguration.Instance.ServerType, features, new OpenSearchPlugins(plugins), numberOfNodes)


### PR DESCRIPTION
Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>

Combines changes from #13 and #14 in one place.