### PR TITLE
Rename `master_timeout` to `cluster_manager_timeout`

### DIFF
--- a/src/ApiGenerator/RestSpecification/Core/cat.allocation.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.allocation.json
@@ -61,6 +61,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.cluster_manager.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.cluster_manager.json
@@ -1,10 +1,14 @@
 {
   "cat.cluster_manager":{
     "documentation":{
-      "url":"https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/",
-      "description":"Returns information about the cluster-manager node."
+      "url":"https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/",
+      "description":"Returns information about the cluster_manager node. Introduced in OpenSearch 2.0 instead of cat.master."
     },
     "stability":"stable",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "text/plain", "application/json"]
+    },
     "url":{
       "paths":[
         {
@@ -44,7 +48,7 @@
       },
       "cluster_manager_timeout":{
         "type":"time",
-        "description":"Explicit operation timeout for connection to cluster-manager node"
+        "description":"Explicit operation timeout for connection to cluster_manager node"
       },
       "h":{
         "type":"list",

--- a/src/ApiGenerator/RestSpecification/Core/cat.cluster_manager.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.cluster_manager.json
@@ -2,7 +2,7 @@
   "cat.cluster_manager":{
     "documentation":{
       "url":"https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/",
-      "description":"Returns information about the cluster_manager node. Introduced in OpenSearch 2.0 instead of cat.master."
+      "description":"Returns information about the cluster_manager node. Introduced in OpenSearch 2.0 instead of cat-master."
     },
     "stability":"stable",
     "visibility":"public",

--- a/src/ApiGenerator/RestSpecification/Core/cat.indices.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.indices.json
@@ -61,6 +61,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.master.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.master.json
@@ -1,8 +1,8 @@
 {
   "cat.master":{
     "documentation":{
-      "url":"https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/",
-      "description":"Returns information about the master node."
+      "url":"https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/",
+      "description":"Returns information about the master node. Deprecated as of OpenSearch 2.0, use cat.cluster_manager instead."
     },
     "stability":"stable",
     "visibility":"public",

--- a/src/ApiGenerator/RestSpecification/Core/cat.master.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.master.json
@@ -2,7 +2,7 @@
   "cat.master":{
     "documentation":{
       "url":"https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/",
-      "description":"Returns information about the master node. Deprecated as of OpenSearch 2.0, use cat.cluster_manager instead."
+      "description":"Returns information about the master node. Deprecated as of OpenSearch 2.0, use cat-cluster_manager instead."
     },
     "stability":"stable",
     "visibility":"public",

--- a/src/ApiGenerator/RestSpecification/Core/cat.nodeattrs.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.nodeattrs.json
@@ -32,6 +32,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.nodes.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.nodes.json
@@ -49,6 +49,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.pending_tasks.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.pending_tasks.json
@@ -32,6 +32,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.plugins.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.plugins.json
@@ -32,6 +32,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.repositories.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.repositories.json
@@ -33,6 +33,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.shards.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.shards.json
@@ -61,6 +61,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.snapshots.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.snapshots.json
@@ -45,6 +45,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.templates.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.templates.json
@@ -44,6 +44,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cat.thread_pool.json
+++ b/src/ApiGenerator/RestSpecification/Core/cat.thread_pool.json
@@ -44,6 +44,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "h":{
         "type":"list",
         "description":"Comma-separated list of column names to display"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.delete_component_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.delete_component_template.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/cluster.exists_component_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.exists_component_template.json
@@ -30,6 +30,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.get_component_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.get_component_template.json
@@ -36,6 +36,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.get_settings.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.get_settings.json
@@ -28,6 +28,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.health.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.health.json
@@ -62,6 +62,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.pending_tasks.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.pending_tasks.json
@@ -26,7 +26,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/cluster.put_component_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.put_component_template.json
@@ -39,7 +39,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/cluster.put_settings.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.put_settings.json
@@ -29,6 +29,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.reroute.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.reroute.json
@@ -50,6 +50,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/cluster.state.json
+++ b/src/ApiGenerator/RestSpecification/Core/cluster.state.json
@@ -74,7 +74,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "flat_settings":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/dangling_indices.delete_dangling_index.json
+++ b/src/ApiGenerator/RestSpecification/Core/dangling_indices.delete_dangling_index.json
@@ -34,9 +34,13 @@
         "type": "time",
         "description": "Explicit operation timeout"
       },
-      "master_timeout": {
-        "type": "time",
-        "description": "Specify timeout for connection to master"
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/dangling_indices.import_dangling_index.json
+++ b/src/ApiGenerator/RestSpecification/Core/dangling_indices.import_dangling_index.json
@@ -34,9 +34,13 @@
         "type": "time",
         "description": "Explicit operation timeout"
       },
-      "master_timeout": {
-        "type": "time",
-        "description": "Specify timeout for connection to master"
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/delete_script.json
+++ b/src/ApiGenerator/RestSpecification/Core/delete_script.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/features.get_features.json
+++ b/src/ApiGenerator/RestSpecification/Core/features.get_features.json
@@ -23,6 +23,10 @@
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/get_script.json
+++ b/src/ApiGenerator/RestSpecification/Core/get_script.json
@@ -28,7 +28,11 @@
     "params":{
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/indices.add_block.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.add_block.json
@@ -36,7 +36,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "ignore_unavailable":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/indices.clone.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.clone.json
@@ -36,9 +36,13 @@
         "type" : "time",
         "description" : "Explicit operation timeout"
       },
-      "master_timeout": {
-        "type" : "time",
-        "description" : "Specify timeout for connection to master"
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "wait_for_active_shards": {
         "type" : "string",

--- a/src/ApiGenerator/RestSpecification/Core/indices.close.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.close.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "ignore_unavailable":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/indices.create.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.create.json
@@ -41,7 +41,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/indices.delete.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.delete.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "ignore_unavailable":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/indices.delete_alias.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.delete_alias.json
@@ -52,7 +52,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/indices.delete_index_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.delete_index_template.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/indices.delete_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.delete_template.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/indices.exists_index_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.exists_index_template.json
@@ -34,6 +34,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/indices.exists_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.exists_template.json
@@ -34,6 +34,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/indices.get.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.get.json
@@ -65,7 +65,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/indices.get_index_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.get_index_template.json
@@ -40,6 +40,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/indices.get_mapping.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.get_mapping.json
@@ -58,7 +58,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/indices.get_settings.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.get_settings.json
@@ -62,7 +62,11 @@
     "params":{
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "ignore_unavailable":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/indices.get_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.get_template.json
@@ -44,6 +44,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/indices.open.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.open.json
@@ -32,7 +32,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "ignore_unavailable":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/indices.put_alias.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.put_alias.json
@@ -55,7 +55,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/indices.put_index_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.put_index_template.json
@@ -40,7 +40,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/indices.put_mapping.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.put_mapping.json
@@ -55,7 +55,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "ignore_unavailable":{
         "type":"boolean",

--- a/src/ApiGenerator/RestSpecification/Core/indices.put_settings.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.put_settings.json
@@ -35,7 +35,11 @@
     "params":{
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "timeout":{
         "type":"time",

--- a/src/ApiGenerator/RestSpecification/Core/indices.put_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.put_template.json
@@ -43,7 +43,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/indices.rollover.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.rollover.json
@@ -57,7 +57,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "wait_for_active_shards":{
         "type":"string",

--- a/src/ApiGenerator/RestSpecification/Core/indices.shrink.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.shrink.json
@@ -40,9 +40,13 @@
         "type" : "time",
         "description" : "Explicit operation timeout"
       },
-      "master_timeout": {
-        "type" : "time",
-        "description" : "Specify timeout for connection to master"
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "wait_for_active_shards": {
         "type" : "string",

--- a/src/ApiGenerator/RestSpecification/Core/indices.simulate_index_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.simulate_index_template.json
@@ -39,7 +39,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/indices.simulate_template.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.simulate_template.json
@@ -45,7 +45,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/indices.split.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.split.json
@@ -40,9 +40,13 @@
         "type" : "time",
         "description" : "Explicit operation timeout"
       },
-      "master_timeout": {
-        "type" : "time",
-        "description" : "Specify timeout for connection to master"
+      "master_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "wait_for_active_shards": {
         "type" : "string",

--- a/src/ApiGenerator/RestSpecification/Core/indices.update_aliases.json
+++ b/src/ApiGenerator/RestSpecification/Core/indices.update_aliases.json
@@ -27,7 +27,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     },
     "body":{

--- a/src/ApiGenerator/RestSpecification/Core/ingest.delete_pipeline.json
+++ b/src/ApiGenerator/RestSpecification/Core/ingest.delete_pipeline.json
@@ -30,6 +30,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/ingest.get_pipeline.json
+++ b/src/ApiGenerator/RestSpecification/Core/ingest.get_pipeline.json
@@ -35,6 +35,10 @@
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/ingest.put_pipeline.json
+++ b/src/ApiGenerator/RestSpecification/Core/ingest.put_pipeline.json
@@ -31,6 +31,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/put_script.json
+++ b/src/ApiGenerator/RestSpecification/Core/put_script.json
@@ -51,7 +51,11 @@
       },
       "master_timeout":{
         "type":"time",
-        "description":"Specify timeout for connection to master"
+        "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "context":{
         "type":"string",

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.cleanup_repository.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.cleanup_repository.json
@@ -27,12 +27,16 @@
     },
     "params": {
       "master_timeout": {
-        "type" : "time",
-        "description" : "Explicit operation timeout for connection to master node"
+        "type": "time",
+        "description": "Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout": {
+        "type": "time",
+        "description": "Explicit operation timeout for connection to cluster_manager_timeout node"
       },
       "timeout": {
-        "type" : "time",
-        "description" : "Explicit operation timeout"
+        "type": "time",
+        "description": "Explicit operation timeout"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.clone.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.clone.json
@@ -38,7 +38,11 @@
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
-      }
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
     },
     "body":{
       "description":"The snapshot clone definition",

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.create.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.create.json
@@ -36,6 +36,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "wait_for_completion":{
         "type":"boolean",
         "description":"Should this request wait until the operation has completed before returning",

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.create_repository.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.create_repository.json
@@ -32,6 +32,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.delete.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.delete.json
@@ -33,6 +33,10 @@
       "master_timeout":{
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
+      },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
       }
     }
   }

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.delete_repository.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.delete_repository.json
@@ -30,6 +30,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.get.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.get.json
@@ -34,6 +34,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "ignore_unavailable":{
         "type":"boolean",
         "description":"Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.get_repository.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.get_repository.json
@@ -36,6 +36,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "local":{
         "type":"boolean",
         "description":"Return local information, do not retrieve the state from master node (default: false)"

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.restore.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.restore.json
@@ -35,6 +35,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "wait_for_completion":{
         "type":"boolean",
         "description":"Should this request wait until the operation has completed before returning",

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.status.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.status.json
@@ -52,6 +52,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "ignore_unavailable":{
         "type":"boolean",
         "description":"Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown"

--- a/src/ApiGenerator/RestSpecification/Core/snapshot.verify_repository.json
+++ b/src/ApiGenerator/RestSpecification/Core/snapshot.verify_repository.json
@@ -30,6 +30,10 @@
         "type":"time",
         "description":"Explicit operation timeout for connection to master node"
       },
+      "cluster_manager_timeout":{
+        "type":"time",
+        "description":"Explicit operation timeout for connection to cluster_manager_timeout node"
+      },
       "timeout":{
         "type":"time",
         "description":"Explicit operation timeout"

--- a/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRecord.cs
@@ -29,6 +29,10 @@ using System.Runtime.Serialization;
 
 namespace OpenSearch.Client
 {
+	/// <summary>
+	/// See docs <see href="https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/">here</see>
+	/// </summary>
+	/// <remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMasterRecord"/></remarks>
 	[DataContract]
 	public class CatClusterManagerRecord : ICatRecord
 	{
@@ -37,6 +41,9 @@ namespace OpenSearch.Client
 
 		[DataMember(Name ="ip")]
 		public string Ip { get; set; }
+
+		[DataMember(Name ="host")]
+		public string Host { get; set; }
 
 		[DataMember(Name ="node")]
 		public string Node { get; set; }

--- a/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatClusterManager/CatClusterManagerRequest.cs
@@ -28,9 +28,12 @@
 namespace OpenSearch.Client
 {
 	[MapsApi("cat.cluster_manager.json")]
+	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="ICatMasterRequest"/></remarks>
 	public partial interface ICatClusterManagerRequest { }
 
+	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMasterRequest"/></remarks>
 	public partial class CatClusterManagerRequest { }
 
+	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMasterDescriptor"/></remarks>
 	public partial class CatClusterManagerDescriptor { }
 }

--- a/src/OpenSearch.Client/Cat/CatMaster/CatMasterRecord.cs
+++ b/src/OpenSearch.Client/Cat/CatMaster/CatMasterRecord.cs
@@ -29,6 +29,10 @@ using System.Runtime.Serialization;
 
 namespace OpenSearch.Client
 {
+	/// <summary>
+	/// See docs <see href="https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/">here</see>
+	/// </summary>
+	/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManagerRecord"/> instead</remarks>
 	[DataContract]
 	public class CatMasterRecord : ICatRecord
 	{
@@ -37,6 +41,9 @@ namespace OpenSearch.Client
 
 		[DataMember(Name ="ip")]
 		public string Ip { get; set; }
+
+		[DataMember(Name ="host")]
+		public string Host { get; set; }
 
 		[DataMember(Name ="node")]
 		public string Node { get; set; }

--- a/src/OpenSearch.Client/Cat/CatMaster/CatMasterRequest.cs
+++ b/src/OpenSearch.Client/Cat/CatMaster/CatMasterRequest.cs
@@ -28,9 +28,12 @@
 namespace OpenSearch.Client
 {
 	[MapsApi("cat.master.json")]
+	/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="ICatClusterManagerRequest"/> instead</remarks>
 	public partial interface ICatMasterRequest { }
 
+	/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManagerRequest"/> instead</remarks>
 	public partial class CatMasterRequest { }
 
+	/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManagerDescriptor"/> instead</remarks>
 	public partial class CatMasterDescriptor { }
 }

--- a/src/OpenSearch.Client/Descriptors.Cat.cs
+++ b/src/OpenSearch.Client/Descriptors.Cat.cs
@@ -123,7 +123,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatAllocationDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatAllocationDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatAllocationDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatAllocationDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -277,7 +281,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatIndicesDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatIndicesDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatIndicesDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Set to true to return stats only for primary shards</summary>
 		public CatIndicesDescriptor Pri(bool? pri = true) => Qs("pri", pri);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -286,11 +294,8 @@ namespace OpenSearch.Client
 		public CatIndicesDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	/// <summary>
-	/// Descriptor for Master
-	/// <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</para>
-	/// Replaced by <see cref="CatClusterManagerDescriptor"/> in OpenSearch 2.0
-	/// </summary>
+	///<summary>Descriptor for Master <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
+	///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManagerDescriptor"/> instead</remarks>
 	public partial class CatMasterDescriptor : RequestDescriptorBase<CatMasterDescriptor, CatMasterRequestParameters, ICatMasterRequest>, ICatMasterRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatMaster;
@@ -312,10 +317,8 @@ namespace OpenSearch.Client
 		public CatMasterDescriptor Verbose(bool? verbose = true) => Qs("v", verbose);
 	}
 
-	/// <summary>
-	/// Descriptor for cluster_manager
-	/// <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</para>
-	/// </summary>
+	///<summary>Descriptor for Master <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
+	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMasterDescriptor"/></remarks>
 	public partial class CatClusterManagerDescriptor : RequestDescriptorBase<CatClusterManagerDescriptor, CatClusterManagerRequestParameters, ICatClusterManagerRequest>, ICatClusterManagerRequest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatClusterManager;
@@ -329,8 +332,8 @@ namespace OpenSearch.Client
 		public CatClusterManagerDescriptor Help(bool? help = true) => Qs("help", help);
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatClusterManagerDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Explicit operation timeout for connection to master node</summary>
-		public CatClusterManagerDescriptor ClusterManagerTimeout(Time mastertimeout) => Qs("cluster_manager_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		public CatClusterManagerDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatClusterManagerDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -352,7 +355,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatNodeAttributesDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatNodeAttributesDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatNodeAttributesDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatNodeAttributesDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -376,7 +383,11 @@ namespace OpenSearch.Client
 		///<summary>Return help information</summary>
 		public CatNodesDescriptor Help(bool? help = true) => Qs("help", help);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatNodesDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatNodesDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatNodesDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -398,7 +409,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatPendingTasksDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatPendingTasksDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatPendingTasksDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatPendingTasksDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -422,7 +437,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatPluginsDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatPluginsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatPluginsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatPluginsDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -487,7 +506,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node</summary>
 		public CatRepositoriesDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatRepositoriesDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatRepositoriesDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatRepositoriesDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -569,7 +592,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatShardsDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatShardsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatShardsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatShardsDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -605,7 +632,11 @@ namespace OpenSearch.Client
 		///<summary>Set to true to ignore unavailable snapshots</summary>
 		public CatSnapshotsDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatSnapshotsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatSnapshotsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatSnapshotsDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -667,7 +698,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatTemplatesDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatTemplatesDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatTemplatesDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatTemplatesDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>
@@ -703,7 +738,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public CatThreadPoolDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CatThreadPoolDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CatThreadPoolDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
 		public CatThreadPoolDescriptor SortByColumns(params string[] sortbycolumns) => Qs("s", sortbycolumns);
 		///<summary>Verbose mode. Display column headers</summary>

--- a/src/OpenSearch.Client/Descriptors.Cluster.cs
+++ b/src/OpenSearch.Client/Descriptors.Cluster.cs
@@ -89,7 +89,11 @@ namespace OpenSearch.Client
 		///<summary>Whether to return all default clusters setting.</summary>
 		public ClusterGetSettingsDescriptor IncludeDefaults(bool? includedefaults = true) => Qs("include_defaults", includedefaults);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ClusterGetSettingsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ClusterGetSettingsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public ClusterGetSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -126,7 +130,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public ClusterHealthDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ClusterHealthDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ClusterHealthDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public ClusterHealthDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Wait until the specified number of shards is active</summary>
@@ -151,8 +159,12 @@ namespace OpenSearch.Client
 		// Request parameters
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public ClusterPendingTasksDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ClusterPendingTasksDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ClusterPendingTasksDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for PostVotingConfigExclusions <para></para></summary>
@@ -178,7 +190,11 @@ namespace OpenSearch.Client
 		///<summary>Return settings in flat format (default: false)</summary>
 		public ClusterPutSettingsDescriptor FlatSettings(bool? flatsettings = true) => Qs("flat_settings", flatsettings);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ClusterPutSettingsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ClusterPutSettingsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public ClusterPutSettingsDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -202,7 +218,11 @@ namespace OpenSearch.Client
 		///<summary>Return an explanation of why the commands can or cannot be executed</summary>
 		public ClusterRerouteDescriptor Explain(bool? explain = true) => Qs("explain", explain);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ClusterRerouteDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ClusterRerouteDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Limit the information returned to the specified metrics. Defaults to all but metadata</summary>
 		public ClusterRerouteDescriptor Metric(params string[] metric) => Qs("metric", metric);
 		///<summary>Retries allocation of shards that are blocked due to too many subsequent allocation failures</summary>
@@ -256,8 +276,12 @@ namespace OpenSearch.Client
 		public ClusterStateDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public ClusterStateDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ClusterStateDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ClusterStateDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Wait for the metadata version to be equal or greater than the specified metadata version</summary>
 		public ClusterStateDescriptor WaitForMetadataVersion(long? waitformetadataversion) => Qs("wait_for_metadata_version", waitformetadataversion);
 		///<summary>The maximum time to wait for wait_for_metadata_version before timing out</summary>

--- a/src/OpenSearch.Client/Descriptors.DanglingIndices.cs
+++ b/src/OpenSearch.Client/Descriptors.DanglingIndices.cs
@@ -77,8 +77,12 @@ namespace OpenSearch.Client
 		// Request parameters
 		///<summary>Must be set to true in order to delete the dangling index</summary>
 		public DeleteDanglingIndexDescriptor AcceptDataLoss(bool? acceptdataloss = true) => Qs("accept_data_loss", acceptdataloss);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteDanglingIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteDanglingIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public DeleteDanglingIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -104,8 +108,12 @@ namespace OpenSearch.Client
 		// Request parameters
 		///<summary>Must be set to true in order to import the dangling index</summary>
 		public ImportDanglingIndexDescriptor AcceptDataLoss(bool? acceptdataloss = true) => Qs("accept_data_loss", acceptdataloss);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ImportDanglingIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ImportDanglingIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public ImportDanglingIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}

--- a/src/OpenSearch.Client/Descriptors.Indices.cs
+++ b/src/OpenSearch.Client/Descriptors.Indices.cs
@@ -90,8 +90,12 @@ namespace OpenSearch.Client
 		public AddIndexBlockDescriptor ExpandWildcards(ExpandWildcards? expandwildcards) => Qs("expand_wildcards", expandwildcards);
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public AddIndexBlockDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public AddIndexBlockDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public AddIndexBlockDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public AddIndexBlockDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -191,8 +195,12 @@ namespace OpenSearch.Client
 		public CloneIndexDescriptor Index<TOther>()
 			where TOther : class => Assign(typeof(TOther), (a, v) => a.RouteValues.Required("index", (IndexName)v));
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CloneIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CloneIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public CloneIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Set the number of active shards to wait for on the cloned index before the operation returns.</summary>
@@ -231,8 +239,12 @@ namespace OpenSearch.Client
 		public CloseIndexDescriptor ExpandWildcards(ExpandWildcards? expandwildcards) => Qs("expand_wildcards", expandwildcards);
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public CloseIndexDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CloseIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CloseIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public CloseIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Sets the number of active shards to wait for before the operation returns.</summary>
@@ -265,8 +277,12 @@ namespace OpenSearch.Client
 		// Request parameters
 		///<summary>Whether a type should be expected in the body of the mappings.</summary>
 		public CreateIndexDescriptor IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CreateIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CreateIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public CreateIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Set the number of active shards to wait for before the operation returns.</summary>
@@ -305,8 +321,12 @@ namespace OpenSearch.Client
 		public DeleteIndexDescriptor ExpandWildcards(ExpandWildcards? expandwildcards) => Qs("expand_wildcards", expandwildcards);
 		///<summary>Ignore unavailable indexes (default: false)</summary>
 		public DeleteIndexDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public DeleteIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -339,8 +359,12 @@ namespace OpenSearch.Client
 		///<summary>A shortcut into calling Index(Indices.All)</summary>
 		public DeleteAliasDescriptor AllIndices() => Index(Indices.All);
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteAliasDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteAliasDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit timestamp for the document</summary>
 		public DeleteAliasDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -364,8 +388,12 @@ namespace OpenSearch.Client
 		// values part of the url path
 		Name IDeleteIndexTemplateRequest.Name => Self.RouteValues.Get<Name>("name");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteIndexTemplateDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteIndexTemplateDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public DeleteIndexTemplateDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -477,8 +505,13 @@ namespace OpenSearch.Client
 		public IndexTemplateExistsDescriptor FlatSettings(bool? flatsettings = true) => Qs("flat_settings", flatsettings);
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public IndexTemplateExistsDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public IndexTemplateExistsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public IndexTemplateExistsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for TypeExists <para>https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/exists/</para></summary>
@@ -635,8 +668,12 @@ namespace OpenSearch.Client
 		public GetIndexDescriptor IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public GetIndexDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for GetAlias <para>https://opensearch.org/docs/latest/opensearch/rest-api/alias/</para></summary>
@@ -771,8 +808,12 @@ namespace OpenSearch.Client
 		public GetMappingDescriptor<TDocument> IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Whether to add the type name to the response (default: false)</summary>
 		public GetMappingDescriptor<TDocument> IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetMappingDescriptor<TDocument> MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetMappingDescriptor<TDocument> ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for GetSettings <para></para></summary>
@@ -828,8 +869,12 @@ namespace OpenSearch.Client
 		public GetIndexSettingsDescriptor IncludeDefaults(bool? includedefaults = true) => Qs("include_defaults", includedefaults);
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public GetIndexSettingsDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetIndexSettingsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetIndexSettingsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for GetTemplate <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-templates/</para></summary>
@@ -858,8 +903,13 @@ namespace OpenSearch.Client
 		public GetIndexTemplateDescriptor IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public GetIndexTemplateDescriptor Local(bool? local = true) => Qs("local", local);
-		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetIndexTemplateDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetIndexTemplateDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for Open <para>https://opensearch.org/docs/latest/opensearch/rest-api/index-apis/close-index/</para></summary>
@@ -894,8 +944,12 @@ namespace OpenSearch.Client
 		public OpenIndexDescriptor ExpandWildcards(ExpandWildcards? expandwildcards) => Qs("expand_wildcards", expandwildcards);
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public OpenIndexDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public OpenIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public OpenIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public OpenIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Sets the number of active shards to wait for before the operation returns.</summary>
@@ -930,8 +984,12 @@ namespace OpenSearch.Client
 		///<summary>A shortcut into calling Index(Indices.All)</summary>
 		public PutAliasDescriptor AllIndices() => Index(Indices.All);
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public PutAliasDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public PutAliasDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit timestamp for the document</summary>
 		public PutAliasDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -969,8 +1027,12 @@ namespace OpenSearch.Client
 		public PutMappingDescriptor<TDocument> IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Whether a type should be expected in the body of the mappings.</summary>
 		public PutMappingDescriptor<TDocument> IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public PutMappingDescriptor<TDocument> MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public PutMappingDescriptor<TDocument> ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public PutMappingDescriptor<TDocument> Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>When true, applies mappings only to the write index of an alias</summary>
@@ -1010,8 +1072,12 @@ namespace OpenSearch.Client
 		public UpdateIndexSettingsDescriptor FlatSettings(bool? flatsettings = true) => Qs("flat_settings", flatsettings);
 		///<summary>Whether specified concrete indices should be ignored when unavailable (missing or closed)</summary>
 		public UpdateIndexSettingsDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public UpdateIndexSettingsDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public UpdateIndexSettingsDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`</summary>
 		public UpdateIndexSettingsDescriptor PreserveExisting(bool? preserveexisting = true) => Qs("preserve_existing", preserveexisting);
 		///<summary>Explicit operation timeout</summary>
@@ -1041,8 +1107,12 @@ namespace OpenSearch.Client
 		public PutIndexTemplateDescriptor Create(bool? create = true) => Qs("create", create);
 		///<summary>Whether a type should be returned in the body of the mappings.</summary>
 		public PutIndexTemplateDescriptor IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public PutIndexTemplateDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public PutIndexTemplateDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for Refresh <para>https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/</para></summary>
@@ -1134,8 +1204,12 @@ namespace OpenSearch.Client
 		public RolloverIndexDescriptor DryRun(bool? dryrun = true) => Qs("dry_run", dryrun);
 		///<summary>Whether a type should be included in the body of the mappings.</summary>
 		public RolloverIndexDescriptor IncludeTypeName(bool? includetypename = true) => Qs("include_type_name", includetypename);
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public RolloverIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public RolloverIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public RolloverIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Set the number of active shards to wait for on the newly created rollover index before the operation returns.</summary>
@@ -1203,8 +1277,12 @@ namespace OpenSearch.Client
 		public ShrinkIndexDescriptor Index<TOther>()
 			where TOther : class => Assign(typeof(TOther), (a, v) => a.RouteValues.Required("index", (IndexName)v));
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public ShrinkIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public ShrinkIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public ShrinkIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Set the number of active shards to wait for on the shrunken index before the operation returns.</summary>
@@ -1237,8 +1315,12 @@ namespace OpenSearch.Client
 		public SplitIndexDescriptor Index<TOther>()
 			where TOther : class => Assign(typeof(TOther), (a, v) => a.RouteValues.Required("index", (IndexName)v));
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public SplitIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public SplitIndexDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public SplitIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Set the number of active shards to wait for on the shrunken index before the operation returns.</summary>
@@ -1251,8 +1333,12 @@ namespace OpenSearch.Client
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesBulkAlias;
 		// values part of the url path
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public BulkAliasDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public BulkAliasDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Request timeout</summary>
 		public BulkAliasDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}

--- a/src/OpenSearch.Client/Descriptors.Ingest.cs
+++ b/src/OpenSearch.Client/Descriptors.Ingest.cs
@@ -76,7 +76,11 @@ namespace OpenSearch.Client
 		Id IDeletePipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeletePipelineDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeletePipelineDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public DeletePipelineDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -102,7 +106,11 @@ namespace OpenSearch.Client
 		public GetPipelineDescriptor Id(Id id) => Assign(id, (a, v) => a.RouteValues.Optional("id", v));
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetPipelineDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetPipelineDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for GrokProcessorPatterns <para></para></summary>
@@ -133,7 +141,11 @@ namespace OpenSearch.Client
 		Id IPutPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public PutPipelineDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public PutPipelineDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public PutPipelineDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}

--- a/src/OpenSearch.Client/Descriptors.NoNamespace.cs
+++ b/src/OpenSearch.Client/Descriptors.NoNamespace.cs
@@ -440,8 +440,12 @@ namespace OpenSearch.Client
 		// values part of the url path
 		Id IDeleteScriptRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection tomaster node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteScriptDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection tocluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteScriptDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public DeleteScriptDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -781,8 +785,12 @@ namespace OpenSearch.Client
 		// values part of the url path
 		Id IGetScriptRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection tomaster node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetScriptDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection tocluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetScriptDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for Source <para>https://opensearch.org/docs/latest/opensearch/rest-api/document-apis/get-documents/</para></summary>
@@ -1154,8 +1162,12 @@ namespace OpenSearch.Client
 		///<summary>Script context</summary>
 		public PutScriptDescriptor Context(Name context) => Assign(context, (a, v) => a.RouteValues.Optional("context", v));
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection tomaster node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public PutScriptDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Specify timeout for connection tocluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public PutScriptDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public PutScriptDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}

--- a/src/OpenSearch.Client/Descriptors.Snapshot.cs
+++ b/src/OpenSearch.Client/Descriptors.Snapshot.cs
@@ -76,7 +76,11 @@ namespace OpenSearch.Client
 		Name ICleanupRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CleanupRepositoryDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CleanupRepositoryDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public CleanupRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -105,7 +109,11 @@ namespace OpenSearch.Client
 		Name ICloneSnapshotRequest.TargetSnapshot => Self.RouteValues.Get<Name>("target_snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CloneSnapshotDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CloneSnapshotDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for Snapshot <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-snapshots/</para></summary>
@@ -130,7 +138,11 @@ namespace OpenSearch.Client
 		Name ISnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public SnapshotDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public SnapshotDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Should this request wait until the operation has completed before returning</summary>
 		public SnapshotDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
@@ -155,7 +167,11 @@ namespace OpenSearch.Client
 		Name ICreateRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public CreateRepositoryDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public CreateRepositoryDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public CreateRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 		///<summary>Whether to verify the repository after creation</summary>
@@ -184,7 +200,11 @@ namespace OpenSearch.Client
 		Name IDeleteSnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteSnapshotDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteSnapshotDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for DeleteRepository <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-snapshots/</para></summary>
@@ -207,7 +227,11 @@ namespace OpenSearch.Client
 		Names IDeleteRepositoryRequest.RepositoryName => Self.RouteValues.Get<Names>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public DeleteRepositoryDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public DeleteRepositoryDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public DeleteRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}
@@ -236,7 +260,11 @@ namespace OpenSearch.Client
 		///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown</summary>
 		public GetSnapshotDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetSnapshotDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetSnapshotDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob</summary>
 		public GetSnapshotDescriptor Verbose(bool? verbose = true) => Qs("verbose", verbose);
 	}
@@ -264,7 +292,11 @@ namespace OpenSearch.Client
 		///<summary>Return local information, do not retrieve the state from master node (default: false)</summary>
 		public GetRepositoryDescriptor Local(bool? local = true) => Qs("local", local);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public GetRepositoryDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public GetRepositoryDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for Restore <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-snapshots/</para></summary>
@@ -289,7 +321,11 @@ namespace OpenSearch.Client
 		Name IRestoreRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public RestoreDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public RestoreDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Should this request wait until the operation has completed before returning</summary>
 		public RestoreDescriptor WaitForCompletion(bool? waitforcompletion = true) => Qs("wait_for_completion", waitforcompletion);
 	}
@@ -327,7 +363,11 @@ namespace OpenSearch.Client
 		///<summary>Whether to ignore unavailable snapshots, defaults to false which means a SnapshotMissingException is thrown</summary>
 		public SnapshotStatusDescriptor IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public SnapshotStatusDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public SnapshotStatusDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 	}
 
 	///<summary>Descriptor for VerifyRepository <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-snapshots/</para></summary>
@@ -350,7 +390,11 @@ namespace OpenSearch.Client
 		Name IVerifyRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public VerifyRepositoryDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public VerifyRepositoryDescriptor ClusterManagerTimeout(Time timeout) => Qs("cluster_manager_timeout", timeout);
 		///<summary>Explicit operation timeout</summary>
 		public VerifyRepositoryDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
 	}

--- a/src/OpenSearch.Client/OpenSearchClient.Cat.cs
+++ b/src/OpenSearch.Client/OpenSearchClient.Cat.cs
@@ -233,53 +233,57 @@ namespace OpenSearch.Client.Specification.CatApi
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</a>
-		/// Replaced by <see cref="ClusterManager(Func&lt;CatClusterManagerDescriptor, ICatClusterManagerRequest&gt;)"/> in OpenSearch 2.0
+		/// <a href = "https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</a>
+		/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManager(Func&lt;CatClusterManagerDescriptor, ICatClusterManagerRequest&gt;)"/> instead</remarks>
 		/// </summary>
 		public CatResponse<CatMasterRecord> Master(Func<CatMasterDescriptor, ICatMasterRequest> selector = null) => Master(selector.InvokeOrDefault(new CatMasterDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</a>
-		/// Replaced by <see cref="ClusterManagerAsync(Func&lt;CatClusterManagerDescriptor, ICatClusterManagerRequest&gt;, CancellationToken)"/> in OpenSearch 2.0
+		/// <a href = "https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</a>
+		/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerAsync(Func&lt;CatClusterManagerDescriptor, ICatClusterManagerRequest&gt;, CancellationToken)"/> instead</remarks>
 		/// </summary>
 		public Task<CatResponse<CatMasterRecord>> MasterAsync(Func<CatMasterDescriptor, ICatMasterRequest> selector = null, CancellationToken ct = default) => MasterAsync(selector.InvokeOrDefault(new CatMasterDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</a>
-		/// Replaced by <see cref="ClusterManager(ICatClusterManagerRequest)"/> in OpenSearch 2.0
+		/// <a href = "https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</a>
+		/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManager(ICatClusterManagerRequest)"/> instead</remarks>
 		/// </summary>
 		public CatResponse<CatMasterRecord> Master(ICatMasterRequest request) => DoCat<ICatMasterRequest, CatMasterRequestParameters, CatMasterRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.master</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</a>
-		/// Replaced by <see cref="ClusterManagerAsync(ICatClusterManagerRequest, CancellationToken)"/> in OpenSearch 2.0
+		/// <a href = "https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/">https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</a>
+		/// <remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerAsync(ICatClusterManagerRequest, CancellationToken)"/> instead</remarks>
 		/// </summary>
 		public Task<CatResponse<CatMasterRecord>> MasterAsync(ICatMasterRequest request, CancellationToken ct = default) => DoCatAsync<ICatMasterRequest, CatMasterRequestParameters, CatMasterRecord>(request, ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <a href = "https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <remarks>Introduced in OpenSearch 2.0 instead of <see cref="Master(Func&lt;CatMasterDescriptor, ICatMasterRequest&gt;)"/></remarks>
 		/// </summary>
 		public CatResponse<CatClusterManagerRecord> ClusterManager(Func<CatClusterManagerDescriptor, ICatClusterManagerRequest> selector = null) => ClusterManager(selector.InvokeOrDefault(new CatClusterManagerDescriptor()));
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <a href = "https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterAsync(Func&lt;CatMasterDescriptor, ICatMasterRequest&gt;, CancellationToken)"/></remarks>
 		/// </summary>
 		public Task<CatResponse<CatClusterManagerRecord>> ClusterManagerAsync(Func<CatClusterManagerDescriptor, ICatClusterManagerRequest> selector = null, CancellationToken ct = default) => ClusterManagerAsync(selector.InvokeOrDefault(new CatClusterManagerDescriptor()), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <a href = "https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <remarks>Introduced in OpenSearch 2.0 instead of <see cref="Master(ICatMasterRequest)"/></remarks>
 		/// </summary>
 		public CatResponse<CatClusterManagerRecord> ClusterManager(ICatClusterManagerRequest request) => DoCat<ICatClusterManagerRequest, CatClusterManagerRequestParameters, CatClusterManagerRecord>(request);
 		/// <summary>
 		/// <c>GET</c> request to the <c>cat.cluster_manager</c> API, read more about this API online:
 		/// <para></para>
-		/// <a href = "https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <a href = "https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/">https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</a>
+		/// <remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterAsync(ICatMasterRequest, CancellationToken)"/></remarks>
 		/// </summary>
 		public Task<CatResponse<CatClusterManagerRecord>> ClusterManagerAsync(ICatClusterManagerRequest request, CancellationToken ct = default) => DoCatAsync<ICatClusterManagerRequest, CatClusterManagerRequestParameters, CatClusterManagerRecord>(request, ct);
 		/// <summary>

--- a/src/OpenSearch.Client/Requests.Cat.cs
+++ b/src/OpenSearch.Client/Requests.Cat.cs
@@ -211,10 +211,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -556,10 +565,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Set to true to return stats only for primary shards</summary>
@@ -589,10 +607,8 @@ namespace OpenSearch.Client
 	{
 	}
 
-	/// <summary>Request for Master
-	/// <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</para>
-	/// Replaced by <see cref="CatClusterManagerRequest"/> in OpenSearch 2.0
-	/// </summary>
+	///<summary>Request for Master <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
+	///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManagerRequest"/> instead</remarks>
 	public partial class CatMasterRequest : PlainRequestBase<CatMasterRequestParameters>, ICatMasterRequest
 	{
 		protected ICatMasterRequest Self => this;
@@ -658,9 +674,8 @@ namespace OpenSearch.Client
 	{
 	}
 
-	/// <summary>Request for ClusterManager
-	/// <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</para>
-	/// </summary>
+	///<summary>Request for ClusterManager <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
+	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMasterRequest"/></remarks>
 	public partial class CatClusterManagerRequest : PlainRequestBase<CatClusterManagerRequestParameters>, ICatClusterManagerRequest
 	{
 		protected ICatClusterManagerRequest Self => this;
@@ -766,10 +781,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -839,10 +863,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -905,10 +938,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -978,10 +1020,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1135,10 +1186,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1303,10 +1363,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1387,10 +1456,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1555,10 +1633,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1639,10 +1726,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>

--- a/src/OpenSearch.Client/Requests.Cluster.cs
+++ b/src/OpenSearch.Client/Requests.Cluster.cs
@@ -131,10 +131,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -197,10 +206,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -272,11 +290,20 @@ namespace OpenSearch.Client
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -340,10 +367,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -395,10 +431,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Limit the information returned to the specified metrics. Defaults to all but metadata</summary>
@@ -506,11 +551,20 @@ namespace OpenSearch.Client
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Wait for the metadata version to be equal or greater than the specified metadata version</summary>

--- a/src/OpenSearch.Client/Requests.DanglingIndices.cs
+++ b/src/OpenSearch.Client/Requests.DanglingIndices.cs
@@ -95,11 +95,20 @@ namespace OpenSearch.Client
 			set => Q("accept_data_loss", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -148,11 +157,20 @@ namespace OpenSearch.Client
 			set => Q("accept_data_loss", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Client/Requests.Indices.cs
+++ b/src/OpenSearch.Client/Requests.Indices.cs
@@ -121,11 +121,20 @@ namespace OpenSearch.Client
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -291,11 +300,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		IndexName ICloneIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -368,11 +386,20 @@ namespace OpenSearch.Client
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -428,11 +455,20 @@ namespace OpenSearch.Client
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -501,12 +537,20 @@ namespace OpenSearch.Client
 			get => Q<bool? >("ignore_unavailable");
 			set => Q("ignore_unavailable", value);
 		}
-
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -557,11 +601,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		Names IDeleteAliasRequest.Name => Self.RouteValues.Get<Names>("name");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit timestamp for the document</summary>
@@ -603,11 +656,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		Name IDeleteIndexTemplateRequest.Name => Self.RouteValues.Get<Name>("name");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -816,10 +878,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1126,11 +1197,20 @@ namespace OpenSearch.Client
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1370,11 +1450,20 @@ namespace OpenSearch.Client
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1474,11 +1563,20 @@ namespace OpenSearch.Client
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1534,10 +1632,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1596,11 +1703,20 @@ namespace OpenSearch.Client
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1658,11 +1774,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		Name IPutAliasRequest.Name => Self.RouteValues.Get<Name>("name");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit timestamp for the document</summary>
@@ -1739,11 +1864,20 @@ namespace OpenSearch.Client
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1837,11 +1971,20 @@ namespace OpenSearch.Client
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`</summary>
@@ -1904,11 +2047,20 @@ namespace OpenSearch.Client
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -2067,11 +2219,20 @@ namespace OpenSearch.Client
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -2191,11 +2352,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		IndexName IShrinkIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -2253,11 +2423,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		IndexName ISplitIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -2287,11 +2466,20 @@ namespace OpenSearch.Client
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesBulkAlias;
 		// values part of the url path
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Request timeout</summary>

--- a/src/OpenSearch.Client/Requests.Ingest.cs
+++ b/src/OpenSearch.Client/Requests.Ingest.cs
@@ -89,10 +89,19 @@ namespace OpenSearch.Client
 		Id IDeletePipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -134,10 +143,19 @@ namespace OpenSearch.Client
 		Id IGetPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -187,10 +205,19 @@ namespace OpenSearch.Client
 		Id IPutPipelineRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Client/Requests.NoNamespace.cs
+++ b/src/OpenSearch.Client/Requests.NoNamespace.cs
@@ -951,11 +951,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		Id IDeleteScriptRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1669,11 +1678,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		Id IGetScriptRequest.Id => Self.RouteValues.Get<Id>("id");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -2415,11 +2433,20 @@ namespace OpenSearch.Client
 		[IgnoreDataMember]
 		Name IPutScriptRequest.Context => Self.RouteValues.Get<Name>("context");
 		// Request parameters
-		///<summary>Specify timeout for connection to master</summary>
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Client/Requests.Snapshot.cs
+++ b/src/OpenSearch.Client/Requests.Snapshot.cs
@@ -89,10 +89,19 @@ namespace OpenSearch.Client
 		Name ICleanupRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -153,10 +162,19 @@ namespace OpenSearch.Client
 		Name ICloneSnapshotRequest.TargetSnapshot => Self.RouteValues.Get<Name>("target_snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -201,10 +219,19 @@ namespace OpenSearch.Client
 		Name ISnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Should this request wait until the operation has completed before returning</summary>
@@ -247,10 +274,19 @@ namespace OpenSearch.Client
 		Name ICreateRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -309,10 +345,19 @@ namespace OpenSearch.Client
 		Name IDeleteSnapshotRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -348,10 +393,19 @@ namespace OpenSearch.Client
 		Names IDeleteRepositoryRequest.RepositoryName => Self.RouteValues.Get<Names>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -408,12 +462,20 @@ namespace OpenSearch.Client
 			get => Q<bool? >("ignore_unavailable");
 			set => Q("ignore_unavailable", value);
 		}
-
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob</summary>
@@ -462,10 +524,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -510,10 +581,19 @@ namespace OpenSearch.Client
 		Name IRestoreRequest.Snapshot => Self.RouteValues.Get<Name>("snapshot");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Should this request wait until the operation has completed before returning</summary>
@@ -577,10 +657,19 @@ namespace OpenSearch.Client
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -616,10 +705,19 @@ namespace OpenSearch.Client
 		Name IVerifyRepositoryRequest.RepositoryName => Self.RouteValues.Get<Name>("repository");
 		// Request parameters
 		///<summary>Explicit operation timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeout"/> instead</remarks>
 		public Time MasterTimeout
 		{
 			get => Q<Time>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeout"/></remarks>
+		public Time ClusterManagerTimeout
+		{
+			get => Q<Time>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Client/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/OpenSearch.Client/_Generated/ApiUrlsLookup.generated.cs
@@ -47,12 +47,14 @@ namespace OpenSearch.Client
 		internal static ApiUrls NoNamespaceBulk = new ApiUrls(new[]{"_bulk", "{index}/_bulk"});
 		internal static ApiUrls CatAliases = new ApiUrls(new[]{"_cat/aliases", "_cat/aliases/{name}"});
 		internal static ApiUrls CatAllocation = new ApiUrls(new[]{"_cat/allocation", "_cat/allocation/{node_id}"});
-		internal static ApiUrls CatClusterManager = new ApiUrls(new[]{"_cat/cluster_manager"});
 		internal static ApiUrls CatCount = new ApiUrls(new[]{"_cat/count", "_cat/count/{index}"});
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMaster"/></remarks>
+		internal static ApiUrls CatClusterManager = new ApiUrls(new[]{"_cat/cluster_manager"});
 		internal static ApiUrls CatFielddata = new ApiUrls(new[]{"_cat/fielddata", "_cat/fielddata/{fields}"});
 		internal static ApiUrls CatHealth = new ApiUrls(new[]{"_cat/health"});
 		internal static ApiUrls CatHelp = new ApiUrls(new[]{"_cat"});
 		internal static ApiUrls CatIndices = new ApiUrls(new[]{"_cat/indices", "_cat/indices/{index}"});
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManager"/> instead</remarks>
 		internal static ApiUrls CatMaster = new ApiUrls(new[]{"_cat/master"});
 		internal static ApiUrls CatNodeAttributes = new ApiUrls(new[]{"_cat/nodeattrs"});
 		internal static ApiUrls CatNodes = new ApiUrls(new[]{"_cat/nodes"});

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
@@ -154,10 +154,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -417,10 +426,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Set to true to return stats only for primary shards</summary>
@@ -445,11 +463,8 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 	}
 
-	/// <summary>
-	/// Request options for Master
-	/// <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</para>
-	/// Replaced by <see cref="CatClusterManagerRequestParameters"/> in OpenSearch 2.0
-	/// </summary>
+	///<summary>Request options for Master <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
+	///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="CatClusterManagerRequestParameters"/> instead</remarks>
 	public class CatMasterRequestParameters : RequestParameters<CatMasterRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -487,10 +502,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -508,10 +532,8 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 	}
 
-	/// <summary>
-	/// Request options for cluster_manager
-	/// <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</para>
-	/// </summary>
+	///<summary>Request options for ClusterManager <para>https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</para></summary>
+	///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="CatMasterRequestParameters"/></remarks>
 	public class CatClusterManagerRequestParameters : RequestParameters<CatClusterManagerRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
@@ -608,10 +630,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -674,10 +705,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -733,10 +773,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -799,10 +848,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -931,10 +989,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1049,10 +1116,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1108,10 +1184,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1243,10 +1328,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>
@@ -1302,10 +1396,19 @@ namespace OpenSearch.Net.Specification.CatApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Comma-separated list of column names or column aliases to sort by</summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Cluster.cs
@@ -75,11 +75,20 @@ namespace OpenSearch.Net.Specification.ClusterApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -116,10 +125,19 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -136,10 +154,19 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -163,10 +190,19 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -204,10 +240,19 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -272,11 +317,20 @@ namespace OpenSearch.Net.Specification.ClusterApi
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -325,11 +379,20 @@ namespace OpenSearch.Net.Specification.ClusterApi
 			set => Q("create", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -353,10 +416,19 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -394,10 +466,19 @@ namespace OpenSearch.Net.Specification.ClusterApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Limit the information returned to the specified metrics. Defaults to all but metadata</summary>
@@ -465,11 +546,20 @@ namespace OpenSearch.Net.Specification.ClusterApi
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Wait for the metadata version to be equal or greater than the specified metadata version</summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.DanglingIndices.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.DanglingIndices.cs
@@ -62,11 +62,20 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
 			set => Q("accept_data_loss", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -89,11 +98,20 @@ namespace OpenSearch.Net.Specification.DanglingIndicesApi
 			set => Q("accept_data_loss", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Features.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Features.cs
@@ -56,10 +56,19 @@ namespace OpenSearch.Net.Specification.FeaturesApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		public override bool SupportsBody => false;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 }

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
@@ -79,11 +79,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -177,11 +186,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -228,11 +246,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -265,11 +292,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -313,11 +349,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -333,11 +378,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit timestamp for the document</summary>
@@ -353,11 +407,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -373,11 +436,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -493,10 +565,19 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -520,10 +601,19 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -749,11 +839,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -865,10 +964,19 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -908,11 +1016,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -966,11 +1083,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("local", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1001,10 +1127,19 @@ namespace OpenSearch.Net.Specification.IndicesApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1037,11 +1172,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1064,11 +1208,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit timestamp for the document</summary>
@@ -1098,11 +1251,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("create", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1142,11 +1304,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1200,11 +1371,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("ignore_unavailable", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Whether to update existing settings. If set to `true` existing settings on an index remain unchanged, the default is `false`</summary>
@@ -1241,11 +1421,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1331,11 +1520,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("include_type_name", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1432,11 +1630,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1473,11 +1680,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("create", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1500,11 +1716,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 			set => Q("create", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1513,11 +1738,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1609,11 +1843,20 @@ namespace OpenSearch.Net.Specification.IndicesApi
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 		public override bool SupportsBody => true;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Request timeout</summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Ingest.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Ingest.cs
@@ -56,10 +56,19 @@ namespace OpenSearch.Net.Specification.IngestApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -76,10 +85,19 @@ namespace OpenSearch.Net.Specification.IngestApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		public override bool SupportsBody => false;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -96,10 +114,19 @@ namespace OpenSearch.Net.Specification.IngestApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -626,11 +626,20 @@ namespace OpenSearch.Net
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -1001,11 +1010,20 @@ namespace OpenSearch.Net
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		public override bool SupportsBody => false;
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -1469,11 +1487,20 @@ namespace OpenSearch.Net
 			set => Q("context", value);
 		}
 
-		///<summary>Specify timeout for connection to master</summary>
-		public TimeSpan MasterTimeout
+		///<summary>Specify timeout for connection to master node</summary>
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Specify timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Snapshot.cs
+++ b/src/OpenSearch.Net/Api/RequestParameters/RequestParameters.Snapshot.cs
@@ -56,17 +56,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 		public override bool SupportsBody => true;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
 		}
 
-		///<summary>Explicit operation timeout</summary>
-		public TimeSpan Timeout
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
 		{
-			get => Q<TimeSpan>("timeout");
-			set => Q("timeout", value);
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -76,10 +78,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -89,10 +100,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Should this request wait until the operation has completed before returning</summary>
@@ -109,10 +129,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
 		public override bool SupportsBody => true;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -136,10 +165,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -149,10 +187,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>
@@ -176,10 +223,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Whether to show verbose snapshot info or only show the basic info found in the repository index blob</summary>
@@ -203,10 +259,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -216,10 +281,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 		public override bool SupportsBody => true;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Should this request wait until the operation has completed before returning</summary>
@@ -243,10 +317,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		}
 
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 	}
 
@@ -256,10 +339,19 @@ namespace OpenSearch.Net.Specification.SnapshotApi
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 		public override bool SupportsBody => false;
 		///<summary>Explicit operation timeout for connection to master node</summary>
-		public TimeSpan MasterTimeout
+		///<remarks>Deprecated as of OpenSearch 2.0, use <see cref="ClusterManagerTimeSpanout"/> instead</remarks>
+		public TimeSpan MasterTimeSpanout
 		{
 			get => Q<TimeSpan>("master_timeout");
 			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout for connection to cluster_manager node</summary>
+		///<remarks>Introduced in OpenSearch 2.0 instead of <see cref="MasterTimeSpanout"/></remarks>
+		public TimeSpan ClusterManagerTimeSpanout
+		{
+			get => Q<TimeSpan>("cluster_manager_timeout");
+			set => Q("cluster_manager_timeout", value);
 		}
 
 		///<summary>Explicit operation timeout</summary>

--- a/src/OpenSearch.Net/OpenSearchLowLevelClient.Cat.cs
+++ b/src/OpenSearch.Net/OpenSearchLowLevelClient.Cat.cs
@@ -193,20 +193,20 @@ namespace OpenSearch.Net.Specification.CatApi
 		[MapsApi("cat.indices", "index")]
 		public Task<TResponse> IndicesAsync<TResponse>(string index, CatIndicesRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(GET, Url($"_cat/indices/{index:index}"), ctx, null, RequestParams(requestParameters));
-		///<summary>GET on /_cat/master <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</para></summary>
+		///<summary>GET on /_cat/master <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse Master<TResponse>(CatMasterRequestParameters requestParameters = null)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(GET, "_cat/master", null, RequestParams(requestParameters));
-		///<summary>GET on /_cat/master <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-master/</para></summary>
+		///<summary>GET on /_cat/master <para>https://opensearch.org/docs/1.2/opensearch/rest-api/cat/cat-master/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("cat.master", "")]
 		public Task<TResponse> MasterAsync<TResponse>(CatMasterRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequestAsync<TResponse>(GET, "_cat/master", ctx, null, RequestParams(requestParameters));
-		///<summary>GET on /_cat/cluster_manager <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</para></summary>
+		///<summary>GET on /_cat/cluster_manager <para>https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse ClusterManager<TResponse>(CatClusterManagerRequestParameters requestParameters = null)
 			where TResponse : class, IOpenSearchResponse, new() => DoRequest<TResponse>(GET, "_cat/cluster_manager", null, RequestParams(requestParameters));
-		///<summary>GET on /_cat/cluster_manager <para>https://opensearch.org/docs/latest/opensearch/rest-api/cat/cat-cluster_manager/</para></summary>
+		///<summary>GET on /_cat/cluster_manager <para>https://opensearch.org/docs/2.0/opensearch/rest-api/cat/cat-cluster_manager/</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("cat.cluster_manager", "")]
 		public Task<TResponse> ClusterManagerAsync<TResponse>(CatClusterManagerRequestParameters requestParameters = null, CancellationToken ctx = default)

--- a/tests/Tests/Cat/CatClusterManager/CatClusterManagerUrlTests.cs
+++ b/tests/Tests/Cat/CatClusterManager/CatClusterManagerUrlTests.cs
@@ -31,7 +31,7 @@ using OpenSearch.Client;
 using Tests.Framework.EndpointTests;
 using static Tests.Framework.EndpointTests.UrlTester;
 
-namespace Tests.Cat.CatMaster
+namespace Tests.Cat.CatClusterManager
 {
 	public class CatClusterManagerUrlTests : UrlTestsBase
 	{

--- a/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
+++ b/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
@@ -36,6 +36,7 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 namespace Tests.Cat.CatMaster
 {
 	[SkipVersion(">=2.0.0", "CatMaster API was renamed to CatClusterManager in 2.0.0 release")]
+	// TODO
 	public class CatMasterApiTests
 		: ApiIntegrationTestBase<ReadOnlyCluster, CatResponse<CatMasterRecord>, ICatMasterRequest, CatMasterDescriptor, CatMasterRequest>
 	{

--- a/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
+++ b/tests/Tests/Cat/CatMaster/CatMasterApiTests.cs
@@ -36,7 +36,6 @@ using OpenSearch.OpenSearch.Xunit.XunitPlumbing;
 namespace Tests.Cat.CatMaster
 {
 	[SkipVersion(">=2.0.0", "CatMaster API was renamed to CatClusterManager in 2.0.0 release")]
-	// TODO
 	public class CatMasterApiTests
 		: ApiIntegrationTestBase<ReadOnlyCluster, CatResponse<CatMasterRecord>, ICatMasterRequest, CatMasterDescriptor, CatMasterRequest>
 	{


### PR DESCRIPTION
### Description
Signed-off-by: Yury Fridlyand [yuryf@bitquilltech.com](mailto:yuryf@bitquilltech.com)

* Rename `master_timeout` to `cluster_manager_timeout` everywhere it is used;
* Update doc links for `_cat/master` and `_cat/cluster_manager`;
* Add deprecation/introduction info for `CatMaster`/`CatClusterManager` APIs' and tests;
* Update json files with REST spec.