### PR TITLE
Recover `MasterEligible`

### DIFF
--- a/src/OpenSearch.Net.VirtualizedCluster/VirtualCluster.cs
+++ b/src/OpenSearch.Net.VirtualizedCluster/VirtualCluster.cs
@@ -76,6 +76,12 @@ namespace OpenSearch.Net.VirtualizedCluster
 			return this;
 		}
 
+		[Obsolete("Use ClusterManagerEligible instead", false)]
+		public VirtualCluster MasterEligible(params int[] ports)
+		{
+			return ClusterManagerEligible(ports);
+		}
+
 		public VirtualCluster StoresNoData(params int[] ports)
 		{
 			foreach (var node in _nodes.Where(n => ports.Contains(n.Uri.Port)))

--- a/src/OpenSearch.Net/ConnectionPool/Node.cs
+++ b/src/OpenSearch.Net/ConnectionPool/Node.cs
@@ -77,7 +77,14 @@ namespace OpenSearch.Net
 		/// <summary>Indicates whether this node is cluster_manager eligible, defaults to true when unknown/unspecified</summary>
 		public bool ClusterManagerEligible { get; set; }
 
+		/// <summary> Renamed to <see cref="ClusterManagerEligible"/> as of OpenSearch 2.0</summary>
+		[Obsolete("Use ClusterManagerEligible instead", false)]
+		public bool MasterEligible { get => ClusterManagerEligible; set => ClusterManagerEligible = value; }
+
 		public bool ClusterManagerOnlyNode => ClusterManagerEligible && !HoldsData;
+
+		[Obsolete("Use ClusterManagerOnlyNode instead", false)]
+		public bool MasterOnlyNode => ClusterManagerOnlyNode;
 
 		/// <summary>The name of the node, defaults to null when unknown/unspecified</summary>
 		public string Name { get; set; }

--- a/src/OpenSearch.Net/Responses/Sniff/SniffResponse.cs
+++ b/src/OpenSearch.Net/Responses/Sniff/SniffResponse.cs
@@ -116,6 +116,8 @@ namespace OpenSearch.Net
 		internal bool IngestEnabled => roles?.Contains("ingest") ?? false;
 
 		internal bool ClusterManagerEligible => (roles == null ? false : roles.Contains("master") || roles.Contains("cluster_manager"));
+		[Obsolete("Use ClusterManagerEligible instead", false)]
+		internal bool MasterEligible => ClusterManagerEligible;
 	}
 
 	internal class NodeInfoHttp


### PR DESCRIPTION
This PR addresses feedback given in https://github.com/opensearch-project/opensearch-net/pull/51#pullrequestreview-1065706502.

Fix includes:
* Recover `MasterEligible`
* Redirect it to `ClusterManagerEligible`
* Mark as obsolete

Note:
`VirtualizedCluster` used in unit tests only.

Signed-off-by: Yury Fridlyand <yuryf@bitquilltech.com>